### PR TITLE
Fix: Audio truncation, request cancellation, and 500 error resilience

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -29,7 +29,7 @@ async function convertAudio(pcmBuffer, format = 'mp3') {
             '-ar', '24000',       // Input sample rate: 24000 Hz
             '-ac', '1',           // Input channels: mono
             '-i', 'pipe:0',       // Read from stdin
-            // Low latency flags for buffered conversion (less critical here but good practice)
+            // Low latency flags
             '-fflags', 'nobuffer',
             '-flags', 'low_delay',
             '-f', outputFormat,   // Output format
@@ -111,7 +111,6 @@ function createStreamConverter(format, onData, onEnd, onError) {
         // LOW LATENCY OPTIMIZATIONS
         '-fflags', 'nobuffer',    // Do not buffer headers
         '-flags', 'low_delay',    // Optimize for low delay
-        '-asio', '0',             // (Optional) Disable extra I/O buffering if applicable
         '-f', outputFormat,
     ];
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -25,18 +25,13 @@ async function convertAudio(pcmBuffer, format = 'mp3') {
 
         // ffmpeg arguments for converting from PCM
         const args = [
-            // Input Options (must come before -i)
             '-f', 's16le',        // Input format: signed 16-bit little-endian
             '-ar', '24000',       // Input sample rate: 24000 Hz
             '-ac', '1',           // Input channels: mono
-            '-fflags', 'nobuffer', // Reduce input buffering
-            '-analyzeduration', '0', // Skip analyzing audio
-            '-probesize', '32',      // Skip probing
             '-i', 'pipe:0',       // Read from stdin
-            
-            // Output Options
-            '-flags', 'low_delay', // Optimize for low latency
-            '-flush_packets', '1', // Output packets immediately
+            // Low latency flags
+            '-fflags', 'nobuffer',
+            '-flags', 'low_delay',
             '-f', outputFormat,   // Output format
         ];
 
@@ -109,18 +104,13 @@ function createStreamConverter(format, onData, onEnd, onError) {
     const outputFormat = format === 'mp3' ? 'mp3' : format;
 
     const args = [
-        // Input Options (Optimized for Latency)
         '-f', 's16le',
         '-ar', '24000',
         '-ac', '1',
-        '-fflags', 'nobuffer',
-        '-analyzeduration', '0',
-        '-probesize', '32',
         '-i', 'pipe:0',
-        
-        // Output Options
-        '-flags', 'low_delay',
-        '-flush_packets', '1',
+        // LOW LATENCY OPTIMIZATIONS
+        '-fflags', 'nobuffer',    // Do not buffer headers
+        '-flags', 'low_delay',    // Optimize for low delay
         '-f', outputFormat,
     ];
 

--- a/src/converter.js
+++ b/src/converter.js
@@ -25,13 +25,18 @@ async function convertAudio(pcmBuffer, format = 'mp3') {
 
         // ffmpeg arguments for converting from PCM
         const args = [
+            // Input Options (must come before -i)
             '-f', 's16le',        // Input format: signed 16-bit little-endian
             '-ar', '24000',       // Input sample rate: 24000 Hz
             '-ac', '1',           // Input channels: mono
+            '-fflags', 'nobuffer', // Reduce input buffering
+            '-analyzeduration', '0', // Skip analyzing audio
+            '-probesize', '32',      // Skip probing
             '-i', 'pipe:0',       // Read from stdin
-            // Low latency flags
-            '-fflags', 'nobuffer',
-            '-flags', 'low_delay',
+            
+            // Output Options
+            '-flags', 'low_delay', // Optimize for low latency
+            '-flush_packets', '1', // Output packets immediately
             '-f', outputFormat,   // Output format
         ];
 
@@ -104,13 +109,18 @@ function createStreamConverter(format, onData, onEnd, onError) {
     const outputFormat = format === 'mp3' ? 'mp3' : format;
 
     const args = [
+        // Input Options (Optimized for Latency)
         '-f', 's16le',
         '-ar', '24000',
         '-ac', '1',
+        '-fflags', 'nobuffer',
+        '-analyzeduration', '0',
+        '-probesize', '32',
         '-i', 'pipe:0',
-        // LOW LATENCY OPTIMIZATIONS
-        '-fflags', 'nobuffer',    // Do not buffer headers
-        '-flags', 'low_delay',    // Optimize for low delay
+        
+        // Output Options
+        '-flags', 'low_delay',
+        '-flush_packets', '1',
         '-f', outputFormat,
     ];
 

--- a/src/gemini.js
+++ b/src/gemini.js
@@ -9,15 +9,14 @@ const logger = require('./logger');
 const GEMINI_TTS_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:generateContent';
 const GEMINI_TTS_STREAM_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-tts:streamGenerateContent';
 
+// Helper function to delay execution
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
 /**
  * Generate speech using Gemini TTS API (non-streaming)
- * 
- * @param {string} text - Text to convert to speech
- * @param {string} voiceName - Gemini voice name (e.g., 'Kore', 'Charon')
- * @param {string} apiKey - Gemini API key
- * @returns {Promise<Buffer>} - Raw PCM audio buffer (s16le, 24000Hz, mono)
+ * Includes retry logic for 5xx errors
  */
-async function generateSpeech(text, voiceName, apiKey) {
+async function generateSpeech(text, voiceName, apiKey, retries = 3) {
     if (!apiKey) {
         throw new Error('GEMINI_API_KEY is not configured');
     }
@@ -40,58 +39,77 @@ async function generateSpeech(text, voiceName, apiKey) {
         }
     };
 
-    logger.debug('Sending request to Gemini TTS API', {
-        text: text.substring(0, 100) + (text.length > 100 ? '...' : ''),
-        voiceName,
-        url: GEMINI_TTS_URL
-    });
+    let lastError;
+    
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            logger.debug(`Sending request to Gemini TTS API (Attempt ${attempt}/${retries})`, {
+                text: text.substring(0, 100) + (text.length > 100 ? '...' : ''),
+                voiceName,
+                url: GEMINI_TTS_URL
+            });
 
-    const startTime = Date.now();
+            const startTime = Date.now();
 
-    const response = await fetch(`${GEMINI_TTS_URL}?key=${apiKey}`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody)
-    });
+            const response = await fetch(`${GEMINI_TTS_URL}?key=${apiKey}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(requestBody)
+            });
 
-    const elapsed = Date.now() - startTime;
+            const elapsed = Date.now() - startTime;
 
-    if (!response.ok) {
-        const errorText = await response.text();
-        logger.error(`Gemini API error (${response.status})`, errorText);
-        throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+            if (!response.ok) {
+                const errorText = await response.text();
+                // If it's a server error (5xx), throw to trigger retry
+                if (response.status >= 500) {
+                    throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+                }
+                // For client errors (4xx), don't retry, just log and throw
+                logger.error(`Gemini API error (${response.status})`, errorText);
+                throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+            }
+
+            const data = await response.json();
+            logger.debug(`Gemini API response received in ${elapsed}ms`);
+
+            // Extract audio data from response
+            const audioData = data?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+
+            if (!audioData) {
+                logger.error('No audio data in Gemini response', data);
+                throw new Error('No audio data received from Gemini API');
+            }
+
+            // Decode base64 to buffer
+            const pcmBuffer = Buffer.from(audioData, 'base64');
+            logger.info(`Generated ${pcmBuffer.length} bytes of PCM audio for "${text.substring(0, 50)}..." using voice ${voiceName}`);
+
+            return pcmBuffer;
+
+        } catch (error) {
+            lastError = error;
+            logger.warn(`Attempt ${attempt} failed: ${error.message}`);
+            
+            // If we have retries left, wait and continue
+            if (attempt < retries) {
+                const delay = attempt * 1000; // Linear backoff: 1s, 2s, 3s...
+                logger.info(`Retrying in ${delay}ms...`);
+                await sleep(delay);
+            }
+        }
     }
 
-    const data = await response.json();
-    logger.debug(`Gemini API response received in ${elapsed}ms`);
-
-    // Extract audio data from response
-    const audioData = data?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
-
-    if (!audioData) {
-        logger.error('No audio data in Gemini response', data);
-        throw new Error('No audio data received from Gemini API');
-    }
-
-    // Decode base64 to buffer
-    const pcmBuffer = Buffer.from(audioData, 'base64');
-    logger.info(`Generated ${pcmBuffer.length} bytes of PCM audio for "${text.substring(0, 50)}..." using voice ${voiceName}`);
-
-    return pcmBuffer;
+    throw lastError;
 }
 
 /**
  * Generate speech using Gemini TTS API with streaming (SSE)
- * * @param {string} text - Text to convert to speech
- * @param {string} voiceName - Gemini voice name
- * @param {string} apiKey - Gemini API key
- * @param {function} onChunk - Callback for each PCM chunk (Buffer)
- * @param {AbortSignal} [signal] - Optional abort signal to cancel the request
- * @returns {Promise<void>}
+ * Includes retry logic for 5xx errors on initial connection
  */
-async function generateSpeechStream(text, voiceName, apiKey, onChunk, signal) {
+async function generateSpeechStream(text, voiceName, apiKey, onChunk, signal, retries = 3) {
     if (!apiKey) {
         throw new Error('GEMINI_API_KEY is not configured');
     }
@@ -114,30 +132,60 @@ async function generateSpeechStream(text, voiceName, apiKey, onChunk, signal) {
         }
     };
 
-    logger.debug('Sending streaming request to Gemini TTS API', {
-        text: text.substring(0, 100) + (text.length > 100 ? '...' : ''),
-        voiceName,
-        url: GEMINI_TTS_STREAM_URL
-    });
+    let response;
+    let lastError;
 
-    const startTime = Date.now();
+    // Retry loop for the initial connection
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            logger.debug(`Sending streaming request to Gemini TTS API (Attempt ${attempt}/${retries})`, {
+                text: text.substring(0, 100) + (text.length > 100 ? '...' : ''),
+                voiceName,
+                url: GEMINI_TTS_STREAM_URL
+            });
 
-    // UPDATE 1: Pass 'signal' to fetch for cancellation support
-    const response = await fetch(`${GEMINI_TTS_STREAM_URL}?alt=sse&key=${apiKey}`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestBody),
-        signal 
-    });
+            // Pass 'signal' to fetch for cancellation support
+            response = await fetch(`${GEMINI_TTS_STREAM_URL}?alt=sse&key=${apiKey}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(requestBody),
+                signal 
+            });
 
-    if (!response.ok) {
-        const errorText = await response.text();
-        logger.error(`Gemini API streaming error (${response.status})`, errorText);
-        throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+            if (!response.ok) {
+                const errorText = await response.text();
+                if (response.status >= 500) {
+                    throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+                }
+                logger.error(`Gemini API streaming error (${response.status})`, errorText);
+                throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+            }
+
+            // If success, break the retry loop
+            break;
+
+        } catch (error) {
+            lastError = error;
+            // Don't retry if the user cancelled
+            if (error.name === 'AbortError' || signal?.aborted) {
+                throw error;
+            }
+
+            logger.warn(`Streaming attempt ${attempt} failed: ${error.message}`);
+            
+            if (attempt < retries) {
+                const delay = attempt * 1000;
+                logger.info(`Retrying stream in ${delay}ms...`);
+                await sleep(delay);
+            } else {
+                throw lastError;
+            }
+        }
     }
 
+    const startTime = Date.now();
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -197,7 +245,6 @@ async function generateSpeechStream(text, voiceName, apiKey, onChunk, signal) {
     } finally {
         reader.releaseLock();
     }
-    
 
     const elapsed = Date.now() - startTime;
     logger.info(`Streamed ${totalBytes} bytes of PCM audio in ${elapsed}ms for "${text.substring(0, 50)}..." using voice ${voiceName}`);

--- a/src/index.js
+++ b/src/index.js
@@ -76,12 +76,11 @@ app.post('/v1/audio/speech', async (req, res) => {
 
         const contentType = getContentType(response_format);
 
-if (stream) {
+        if (stream) {
             // Streaming response
             res.set('Content-Type', contentType);
             res.set('Transfer-Encoding', 'chunked');
 
-            // --- [INSERT START] ---
             // 1. Create the AbortController
             const controller = new AbortController();
             const signal = controller.signal;
@@ -91,7 +90,6 @@ if (stream) {
                 logger.info('Client disconnected, aborting TTS generation');
                 controller.abort();
             });
-            // --- [INSERT END] ---
 
             let bytesSent = 0;
 
@@ -122,13 +120,12 @@ if (stream) {
                 }
             );
 
-            // --- [REPLACE THIS BLOCK] ---
             // 3. Stream from Gemini with signal and abort check
             try {
                 await generateSpeechStream(input, geminiVoice, GEMINI_API_KEY, async (pcmChunk) => {
                     if (signal.aborted) return; // Stop writing if aborted
                     converter.write(pcmChunk);
-                }, signal); // <--- Pass the signal here
+                }, signal);
 
                 converter.end();
             } catch (err) {
@@ -139,9 +136,8 @@ if (stream) {
                 }
                 throw err;
             }
-            // --- [REPLACEMENT END] ---
 
-        } else {} else {
+        } else {
             // Non-streaming response (original behavior)
             const pcmBuffer = await generateSpeech(input, geminiVoice, GEMINI_API_KEY);
             const audioBuffer = await convertAudio(pcmBuffer, response_format);
@@ -202,4 +198,3 @@ app.listen(PORT, HOST, () => {
         logger.info('Gemini API key configured');
     }
 });
-

--- a/src/index.js
+++ b/src/index.js
@@ -85,8 +85,9 @@ app.post('/v1/audio/speech', async (req, res) => {
             const controller = new AbortController();
             const signal = controller.signal;
 
-            // 2. Listen for client disconnect to trigger abort
-            req.on('close', () => {
+            // 2. Listen for response close (Client stopped listening)
+            // CHANGED: req.on('close') -> res.on('close') to avoid premature aborts
+            res.on('close', () => {
                 logger.info('Client disconnected, aborting TTS generation');
                 controller.abort();
             });

--- a/src/index.js
+++ b/src/index.js
@@ -86,10 +86,12 @@ app.post('/v1/audio/speech', async (req, res) => {
             const signal = controller.signal;
 
             // 2. Listen for response close (Client stopped listening)
-            // CHANGED: req.on('close') -> res.on('close') to avoid premature aborts
             res.on('close', () => {
-                logger.info('Client disconnected, aborting TTS generation');
-                controller.abort();
+                // FIXED: Only abort if the response wasn't finished successfully
+                if (!res.writableEnded) {
+                    logger.info('Client disconnected prematurely, aborting TTS generation');
+                    controller.abort();
+                }
             });
 
             let bytesSent = 0;


### PR DESCRIPTION
This PR addresses three issues affecting audio stability and playback reliability :

#### Fixes Audio Truncation:

Problem: Audio would often stop after the first sentence or cut off the very end of the response. This was caused by the SSE stream loop exiting before processing the final buffer data.

Fix: Updated generateSpeechStream in src/gemini.js to properly flush the TextDecoder and process any remaining data in the buffer after the stream reader closes.

#### Implements Proper Request Cancellation:

Problem: When OpenWebUI timed out or retried a request, the server continued processing the old request in the background. This led to "zombie" streams sending duplicate audio later (the "repeating audio" bug #1).

Fix: Added AbortController support to the /v1/audio/speech endpoint. The server now listens for the res.on('close') event and aborts the Gemini API request if the client disconnects before the response is fully written (!res.writableEnded).

#### Adds Retry Logic for Resilience:

Problem: Intermittent 500 Internal Server Error responses from the Gemini API caused audio generation to fail completely for specific sentences, resulting in silence.

Fix: Implemented automatic retry logic (3 attempts with linear backoff) in src/gemini.js for both streaming and non-streaming requests. This allows the server to recover from temporary API glitches transparently.

### Changes:

src/index.js: Added AbortController logic and safe client disconnection handling.

src/gemini.js: Added signal support for cancellation, buffer flushing for truncation fixes, and retry loops for API stability.

### Testing:

Verified that audio no longer cuts off after the first sentence.

Verified that disconnecting the client (stopping playback) immediately kills the server process.

Verified that occasional 500 errors from Gemini are retried successfully without breaking the audio stream.